### PR TITLE
Update digital twin properties readme and minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Deploy
 personal*
+docker-compose.override.yml
 
 # Ignore everything in data/
 data/*

--- a/demos/3 - microns_digital_twin_properties.ipynb
+++ b/demos/3 - microns_digital_twin_properties.ipynb
@@ -146,7 +146,7 @@
     {
      "data": {
       "text/markdown": [
-       "This README file describes the exported properties for the MICrONS digital twin.\n",
+       "This README file describes the `v2` exported properties for the MICrONS digital twin.\n",
        "\n",
        "# Contents\n",
        "Properties are located in the following subdirectories:\n",
@@ -210,9 +210,9 @@
        "    unit_id                 ID of the unit within the scan                                                         [1 - 3]\n",
        "    readout_weight_vector   Readout weights for the unit learned by digital twin model                             [1, 2]\n",
        "    readout_location_x      X coordinate of the readout location, an approximation of \n",
-       "                                receptive field center in stimulus space; (-1, -1) bottom-left, (1, 1) top-right   [1, 2]\n",
+       "                                receptive field center in stimulus space; (-1, -1) top-left, (1, 1) bottom-right   [1, 2]\n",
        "    readout_location_y      Y coordinate of the readout location, an approximation of \n",
-       "                                receptive field center in stimulus space; (-1, -1) bottom-left, (1, 1) top-right   [1, 2]\n",
+       "                                receptive field center in stimulus space; (-1, -1) top-left, (1, 1) bottom-right   [1, 2]\n",
        "    cc_abs                  Test set performance of the digital twin model unit, higher is better                  [1, 2]\n",
        "    cc_max                  Neuron variability score used to normalize digital twin model unit performance         [1, 2]\n",
        "    cc_norm                 Normalized model unit performance, higher is better                                    [1, 2]\n",

--- a/demos/6 - evaluate_digital_twin.ipynb
+++ b/demos/6 - evaluate_digital_twin.ipynb
@@ -151,14 +151,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "9e7e8ee3-2b66-46ba-bc91-b08dc246cde5",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "units_fmt = evaluate.format_responses(evaluation_data['units'], burnin_frames=10)"
+    "units_fmt = evaluate.format_responses(evaluation_data['units'], burnin_frames=config['objective']['burnin_frames'])"
    ]
   },
   {


### PR DESCRIPTION
# Major change
The README was updated in the digital twin properties notebook: `demos/3 - microns_digital_twin_properties.ipynb`
- The description for readout locations was incorrect. It has been corrected to the following:
```
readout_loc_x : X coordinate of the readout location, an approximation of receptive field center in stimulus space; (-1, -1) top-left, (1, 1) bottom-right
readout_loc_y : Y coordinate of the readout location, an approximation of receptive field center in stimulus space; (-1, -1) top-left, (1, 1) bottom-right
```

## Minor changes
- add docker-compose.override.yml to .gitignore
- remove hard coded value for burnin_frames in `demos/6 - evaluate_digital_twin.ipynb`